### PR TITLE
Allow setting of export interval for Librato measurements.

### DIFF
--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -338,10 +338,11 @@ Options can be set in query string, like this:
 * `prefix` - Prefix for all measurement names
 * `tags` - By default provided tags (comma separated list)
 * `tag_{name}` - Value for the tag `name`
+* `min_export_interval` - Go time.Duration format of minimum time between measurement exports.
 
 For example,
 
-    --sink=librato:?username=xyz&token=secret&prefix=k8s&tags=cluster&tag_cluster=staging
+    --sink=librato:?username=xyz&token=secret&prefix=k8s&tags=cluster&tag_cluster=staging&min_export_interval=60s
 
 The librato sink currently only works with accounts, which support [tagged metrics](https://www.librato.com/docs/kb/faq/account_questions/tags_or_sources/).
 


### PR DESCRIPTION
Initial quick hack together of functionality to allow customising the export interval for Librato based on kubernetes/heapster#1755

There is a slight mismatch in the interface here since the last export time is based on when the request was made, not on when the measurements were submitted, but from a practical standpoint this is the most pragmatic.

I'm not so familiar with this codebase so it's possible there's more work to be done.

Building and running a custom version of this is going to be interesting, unless we want to submit this upstream.