### PR TITLE
Handle case where measurements come in without timestamp.

### DIFF
--- a/common/librato/librato.go
+++ b/common/librato/librato.go
@@ -169,7 +169,18 @@ func removeEarlyMeasurements(measurements []Measurement, lastExportTime time.Tim
 	cutOffTime := lastExportTime.Add(minExportInterval)
 
 	for _, m := range measurements {
+		submitMeasurement := false
+
+		// Measurements may come in without a timestamp
+		if m.Time == 0 && time.Now().After(cutOffTime) {
+			submitMeasurement = true
+		}
+
 		if m.Time > cutOffTime.Unix() {
+			submitMeasurement = true
+		}
+
+		if submitMeasurement {
 			validMeasurements = append(validMeasurements, m)
 		}
 	}

--- a/common/librato/librato_test.go
+++ b/common/librato/librato_test.go
@@ -152,3 +152,27 @@ func Test_RemoveEarlyMeasurements_One_Valid_Measurement(t *testing.T) {
 		t.Errorf("expected 1 measurement, but got %d measurements", got)
 	}
 }
+
+func Test_RemoveEarlyMeasurements_Metrics_Without_Timestamp(t *testing.T) {
+	measurements := []Measurement{
+		{
+			Name:  "dummy1",
+			Value: float64(1),
+		},
+	}
+
+	lastExportTime := time.Now().Add(-59 * time.Second)
+	minExportInterval := 60 * time.Second
+	validMeasurements := removeEarlyMeasurements(measurements, lastExportTime, minExportInterval)
+
+	if want, got := 0, len(validMeasurements); want != got {
+		t.Errorf("expected no measurements, but got %d measurements", got)
+	}
+
+	lastExportTime = time.Now().Add(-90 * time.Second)
+	validMeasurements = removeEarlyMeasurements(measurements, lastExportTime, minExportInterval)
+
+	if want, got := 1, len(validMeasurements); want != got {
+		t.Errorf("expected 1 measurement, but got %d measurements", got)
+	}
+}


### PR DESCRIPTION
This could be the reason for quite large gaps in metrics after deploying the previous change.

If a metric lacks a timestamp, we just compare the last export time with `time.Now()` to make the decision of whether to export this measurement or not.