### PR TITLE
Move export interval checking to Librato sink.

### DIFF
--- a/common/librato/librato_test.go
+++ b/common/librato/librato_test.go
@@ -18,7 +18,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	util "k8s.io/client-go/util/testing"
@@ -95,84 +94,4 @@ func TestLibratoClientWriteWithTags(t *testing.T) {
 	expectedBody := `{"tags":{"a":"test"},"measurements":[{"name":"test","value":1.4,"tags":{"test":"tag"}}]}`
 
 	handler.ValidateRequest(t, "/v1/measurements", "POST", &expectedBody)
-}
-
-func Test_RemoveEarlyMeasurements_No_Measurements(t *testing.T) {
-	measurements := make([]Measurement, 0)
-
-	validMeasurements := removeEarlyMeasurements(measurements, time.Now(), 60*time.Second)
-
-	if want, got := 0, len(validMeasurements); want != got {
-		t.Errorf("expected no measurements, but got %d measurements", got)
-	}
-}
-
-func Test_RemoveEarlyMeasurements_No_Valid_Measurements(t *testing.T) {
-	measurements := []Measurement{
-		{
-			Name:  "dummy",
-			Value: float64(1),
-			Time:  time.Now().Unix(),
-		},
-	}
-
-	lastExportTime := time.Now().Add(-30 * time.Second)
-	minExportInterval := 60 * time.Second
-	validMeasurements := removeEarlyMeasurements(measurements, lastExportTime, minExportInterval)
-
-	if want, got := 0, len(validMeasurements); want != got {
-		t.Errorf("expected no measurements, but got %d measurements", got)
-	}
-}
-
-func Test_RemoveEarlyMeasurements_One_Valid_Measurement(t *testing.T) {
-	measurements := []Measurement{
-		{
-			Name:  "dummy1",
-			Value: float64(1),
-			Time:  time.Now().Add(-60 * time.Second).Unix(),
-		},
-		{
-			Name:  "dummy2",
-			Value: float64(2),
-			Time:  time.Now().Add(-30 * time.Second).Unix(),
-		},
-		{
-			Name:  "dummy3",
-			Value: float64(3),
-			Time:  time.Now().Unix(),
-		},
-	}
-
-	lastExportTime := time.Now().Add(-90 * time.Second)
-	minExportInterval := 60 * time.Second
-	validMeasurements := removeEarlyMeasurements(measurements, lastExportTime, minExportInterval)
-
-	if want, got := 1, len(validMeasurements); want != got {
-		t.Errorf("expected 1 measurement, but got %d measurements", got)
-	}
-}
-
-func Test_RemoveEarlyMeasurements_Metrics_Without_Timestamp(t *testing.T) {
-	measurements := []Measurement{
-		{
-			Name:  "dummy1",
-			Value: float64(1),
-		},
-	}
-
-	lastExportTime := time.Now().Add(-59 * time.Second)
-	minExportInterval := 60 * time.Second
-	validMeasurements := removeEarlyMeasurements(measurements, lastExportTime, minExportInterval)
-
-	if want, got := 0, len(validMeasurements); want != got {
-		t.Errorf("expected no measurements, but got %d measurements", got)
-	}
-
-	lastExportTime = time.Now().Add(-90 * time.Second)
-	validMeasurements = removeEarlyMeasurements(measurements, lastExportTime, minExportInterval)
-
-	if want, got := 1, len(validMeasurements); want != got {
-		t.Errorf("expected 1 measurement, but got %d measurements", got)
-	}
 }


### PR DESCRIPTION
Having the export interval checked inside `common/librato` was apparently the wrong choice as multiple batches are coordinated inside of `metrics/sinks/librato` and sent by the client which is in the other directory. We need to do export interval checking at the multi-batch level, so move this logic into the sink instead.

Unfortunately the export interval still needs to be stored in the client as this is the actual part of the whole thing that is configurable (arguably the sink should contain all of the logic, but let's not change that now).

I'm also not bothering to check each individual metric, but just check the last export time against the current time. This means that the extra function is not currently needed, but I'm leaving it there "just in case" it is needed.